### PR TITLE
Fix for test unit failing to build older versions of Drupal core

### DIFF
--- a/src/DrupalL10nCommand.php
+++ b/src/DrupalL10nCommand.php
@@ -30,7 +30,7 @@ class DrupalL10nCommand extends BaseCommand {
   /**
    * {@inheritdoc}
    */
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $handler = new Handler($this->getComposer(), $this->getIO());
     $handler->downloadLocalization(!$input->getOption('no-dev'));
     return 0;

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -236,6 +236,9 @@ class PluginTest extends TestCase {
           'composer/installers' => TRUE,
           'drupal-composer/drupal-l10n' => TRUE,
         ],
+        'audit' => [
+          'block-insecure' => FALSE,
+        ],
       ],
       'extra' => [
         'drupal-l10n' => [


### PR DESCRIPTION
This should allow the test unit to build properly Drupal core 9.x as due to security advisories, composer is being forced-stopped from building them.

Pinging @FlorentTorregrosa 